### PR TITLE
Correct example command to have blank `--cloud-config`

### DIFF
--- a/cluster-autoscaler/cloudprovider/crusoecloud/examples/cluster-autoscaler.yaml
+++ b/cluster-autoscaler/cloudprovider/crusoecloud/examples/cluster-autoscaler.yaml
@@ -144,6 +144,7 @@ spec:
             - --namespace=crusoe-system
             - --logtostderr=true
             - --cloud-provider=crusoecloud
+            - '--cloud-config=""'
             - --nodes=<min>:<max>:<nodepool>
           envFrom:
             - secretRef:


### PR DESCRIPTION
#### What type of PR is this?

/kind documentation

#### What this PR does / why we need it:

Without this, the example's deployment creates pods that fail with:
```
F0224 16:24:16.480105       1 crusoe_cloud_provider.go:182] No config file provided, please specify it via the --cloud-config flag
```

Per flag description: "Empty string for no configuration file."

https://github.com/crusoecloud/k8s-autoscaler/blob/crusoe-cluster-autoscaler-release-1.30.3/cluster-autoscaler/main.go#L116